### PR TITLE
add DELETE_LOCAL_FILE conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ ZH-CN:
 
 You have to install [Watchdog](https://github.com/gorakhargosh/watchdog) first.
 
+	sudo pip install watchdog
+
 And also download Dropbox python SDK [HERE](https://www.dropbox.com/developers/core/sdk).
+
+	pip install dropbox
 
 ## Setup ##
 

--- a/d2pi/auth.py
+++ b/d2pi/auth.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from utils import get_auth_url_and_token, set_token
 
 url, token = get_auth_url_and_token()

--- a/d2pi/config.py.tmp
+++ b/d2pi/config.py.tmp
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 APP_KEY     = ''
 APP_SECRET  = ''
 ACCESS_TYPE = 'app_folder'
@@ -9,3 +10,5 @@ PATH_TO_WATCH = '/Users/guojing/.dropbox-sync'
 MD5_PATH = PATH_TO_WATCH + '-md5'
 AUTO_SYNC_TIME = 60 * 1
 MAX_DOWNLOAD_FILE_SIZE = 1024 * 5
+
+DELETE_LOCAL_FILE = True

--- a/d2pi/downloader.py
+++ b/d2pi/downloader.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
+
 import socket
-from utils import get_client, parse_file_dir, md5_for_file
+from utils import get_client, md5_for_file
 
 
 def download(file_path, save_to_path):

--- a/d2pi/file.py
+++ b/d2pi/file.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import os, time
+import os
+import time
 from datetime import datetime
 from downloader import download
+
 
 class File:
 
@@ -10,19 +12,21 @@ class File:
         return '<Dropbox File %s>' % self.path
 
     def __init__(self, size, rev, thumb_exists, bytes,
-            modified, mime_type, path, is_dir, icon, root,
-            client_mtime, revision):
+                 modified, mime_type, path, is_dir, icon, root,
+                 client_mtime, revision):
         self.size = size
         self.rev = rev
         self.thumb_exists = thumb_exists
         self.bytes = bytes
-        self.modified = datetime.strptime(modified, '%a, %d %b %Y %H:%M:%S +0000')
+        self.modified = datetime.strptime(modified,
+                                          '%a, %d %b %Y %H:%M:%S +0000')
         self.mime_type = mime_type
         self.path = path
         self.is_dir = is_dir
         self.icon = icon
         self.root = root
-        self.client_mtime = datetime.strptime(client_mtime, '%a, %d %b %Y %H:%M:%S +0000')
+        self.client_mtime = datetime.strptime(client_mtime,
+                                              '%a, %d %b %Y %H:%M:%S +0000')
         self.revision = revision
 
     @property
@@ -45,6 +49,6 @@ class File:
         if not self.is_exists():
             return
         (mode, ino, dev, nlink, uid, gid, size,
-                atime, mtime, ctime) = os.stat(self.save_to_dir)
+         atime, mtime, ctime) = os.stat(self.save_to_dir)
         t = time.ctime(mtime)
         return datetime.strptime(t, "%a %b %d %H:%M:%S %Y")

--- a/d2pi/folder.py
+++ b/d2pi/folder.py
@@ -3,13 +3,14 @@
 import os
 from utils import get_client
 
+
 class Folder:
 
     def __repr__(self):
         return '<Dropbox Folder %s>' % self.path
 
     def __init__(self, hash, thumb_exists, bytes,
-            path, is_dir, icon, root, contents):
+                 path, is_dir, icon, root, contents):
         self.hash = hash
         self.thumb_exists = thumb_exists
         self.bytes = bytes
@@ -46,7 +47,7 @@ class Folder:
                 root = c.get('root')
                 contents = c.get('contents')
                 rs.append((hash, thumb_exists, bytes,
-                    path, is_dir, icon, root, contents))
+                           path, is_dir, icon, root, contents))
             else:
                 if c.get('is_dir'):
                     continue
@@ -59,12 +60,12 @@ class Folder:
                 path = c.get('path')
                 is_dir = c.get('is_dir')
                 icon = c.get('icon')
-                root =c.get('root')
+                root = c.get('root')
                 client_mtime = c.get('client_mtime')
                 revision = c.get('revision')
                 rs.append((size, rev, thumb_exists, bytes,
-                    modified, mime_type, path, is_dir, icon, root,
-                    client_mtime, revision))
+                           modified, mime_type, path, is_dir,
+                           icon, root, client_mtime, revision))
         return rs
 
     @classmethod
@@ -80,7 +81,7 @@ class Folder:
         root = md.get('root')
         contents = md.get('contents')
         return cls(hash, thumb_exists, bytes,
-                path, is_dir, icon, root, contents)
+                   path, is_dir, icon, root, contents)
 
     @property
     def save_to_dir(self):

--- a/d2pi/uploader.py
+++ b/d2pi/uploader.py
@@ -2,8 +2,10 @@
 import os
 import sys
 import socket
-from config import PATH_TO_WATCH
-from utils import get_client, parse_file_dir, md5_for_file
+from config import (PATH_TO_WATCH,
+                    DELETE_LOCAL_FILE)
+from utils import get_client, parse_file_dir
+
 
 def upload(file_name, as_file_name):
     print "uploading %s to %s" % (file_name, as_file_name)
@@ -19,6 +21,7 @@ def upload(file_name, as_file_name):
         print 'Error %s' % e
         f.close()
 
+
 def create_folder(path):
     print 'create folder %s' % path
     socket.setdefaulttimeout(10)
@@ -27,6 +30,7 @@ def create_folder(path):
         client.file_create_folder(path)
     except Exception, e:
         print 'Error %s' % e
+
 
 def delete(path):
     print 'delete %s' % path
@@ -45,6 +49,7 @@ def delete(path):
     except:
         pass
 
+
 def move(path, to_path):
     print 'move %s to %s' % (path, to_path)
     socket.setdefaulttimeout(10)
@@ -53,6 +58,7 @@ def move(path, to_path):
         client.file_move(path, to_path)
     except Exception, e:
         print 'Error %s' % e
+
 
 def check_dir_deleted(path=''):
     socket.setdefaulttimeout(10)
@@ -66,7 +72,10 @@ def check_dir_deleted(path=''):
 
     _check_delete(path)
 
+
 def _check_delete(path):
+    if not DELETE_LOCAL_FILE:
+        return
     client = get_client()
     if path == PATH_TO_WATCH:
         return
@@ -76,10 +85,7 @@ def _check_delete(path):
         if m.get('is_deleted'):
             delete(path)
     except:
-        try:
-            delete(path)
-        except:
-            pass
+        pass
 
 if __name__ == "__main__":
     args = sys.argv

--- a/d2pi/utils.py
+++ b/d2pi/utils.py
@@ -4,13 +4,16 @@ from config import APP_KEY, APP_SECRET, ACCESS_TYPE, TOKEN_FILE
 
 sess = session.DropboxSession(APP_KEY, APP_SECRET, ACCESS_TYPE)
 
+
 def get_session():
     return sess
+
 
 def get_auth_url_and_token():
     request_token = sess.obtain_request_token()
     url = sess.build_authorize_url(request_token)
     return url, request_token
+
 
 def set_token(request_token):
     access_token = sess.obtain_access_token(request_token)
@@ -21,6 +24,7 @@ def set_token(request_token):
     except Exception, e:
         token_file.close()
         print 'Can not write to file %s - Error %s' % (TOKEN_FILE, e)
+
 
 def get_token():
     try:
@@ -33,12 +37,14 @@ def get_token():
         print 'Can not read token file %s - Error %s' % (TOKEN_FILE, e)
         return None, None
 
+
 def get_client():
     token_key, token_secret = get_token()
     if token_key and token_secret:
         sess.set_token(token_key, token_secret)
         c = client.DropboxClient(sess)
         return c
+
 
 def parse_file_dir(file_path):
     '''
@@ -48,7 +54,8 @@ def parse_file_dir(file_path):
     f = file_path.split('/')
     return f[-1]
 
-def md5_for_file(f, block_size=2**20):
+
+def md5_for_file(f, block_size=2 ** 20):
     import hashlib
     md5 = hashlib.md5()
     while True:
@@ -57,4 +64,3 @@ def md5_for_file(f, block_size=2**20):
             break
         md5.update(data)
     return md5.digest()
-

--- a/d2pi/watching.py
+++ b/d2pi/watching.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
-import sys, os, time
+
+import os
+import time
+import sys
 from folder import Folder
 from config import PATH_TO_WATCH, AUTO_SYNC_TIME
 from uploader import upload, delete, move, create_folder, check_dir_deleted
 import logging
 from watchdog.observers import Observer
 from watchdog.events import LoggingEventHandler
+
 
 def sync(folder):
     for f in folder.files:
@@ -16,16 +20,19 @@ def sync(folder):
         d.save()
         sync(d)
 
+
 def init():
     if not os.path.exists(PATH_TO_WATCH):
         print 'mkdir %s' % PATH_TO_WATCH
         os.makedirs(PATH_TO_WATCH)
+
 
 def clean():
     return
     if os.path.exists(PATH_TO_WATCH):
         print 'rm -rf %s' % PATH_TO_WATCH
         os.system('rm -rf %s' % PATH_TO_WATCH)
+
 
 def sync_download():
     try:
@@ -34,6 +41,7 @@ def sync_download():
         sync(f)
     except:
         pass
+
 
 def sync_upload(event):
     try:
@@ -44,6 +52,7 @@ def sync_upload(event):
             upload(path, dropbox_path)
     except:
         pass
+
 
 def sync_upload_create(event):
     try:
@@ -57,6 +66,7 @@ def sync_upload_create(event):
     except:
         pass
 
+
 def sync_upload_delete(event):
     try:
         path = event.src_path
@@ -66,16 +76,18 @@ def sync_upload_delete(event):
     except:
         pass
 
+
 def sync_upload_move(event):
     try:
         print dir(event)
         dropbox_to_path = event.dest_path.replace(PATH_TO_WATCH, '')
         dropbox_from_path = event.src_path.replace(PATH_TO_WATCH, '')
         print 'file moved from %s to %s, updating...' % (dropbox_from_path,
-            dropbox_to_path)
+                                                         dropbox_to_path)
         move(dropbox_from_path, dropbox_to_path)
     except:
         pass
+
 
 def go_watch():
     try:
@@ -141,4 +153,3 @@ if __name__ == '__main__':
     if watch:
         while True:
             go_watch()
-


### PR DESCRIPTION
add config of DELETE_LOCAL_FILE, with DELETE_LOCAL_FILE=False, it will not delete local file when file not in Dropbox.

If you have a sync folder named test. When without network, it will not upload to Dropbox. When you connected to network, Drop2Pi will found this folder is not in server. 0.02 version will delete local file or folder, because we think the server version always right. But that will delete the local file you did not if is uploaded.

so with DELETE_LOCAL_FILE=False, it will save your local file.

a little change.
