### PR TITLE
add simple cache and refact delete sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dropbox_token.txt
 build
 *.egg-info
 dist
+test*.py

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ or
 
 	pip install d2pi
 
+## V 0.0.9 ##
+
+**Changes**:
+
+1. add a very simple cache, it's dict in memory.
+2. better sync_download
+
+`sync_download` will be:
+
+1. check metadata and set hash to cache
+2. request dropbox with hash, it no change then return cache object
+
+this will be faster.
+
+and remove `check_dir_deleted`, it will search all folder and sync delete status, may blocked or broken by other events. now new `sync_download` method will handle that.
+
+If file in dropbox and status `is_deleted` is true, and files/folder exists in local, and config require remove local file, then remove local.
+
+If file exists in server with no change, return cache object.
+
 ## V 0.0.5 ##
 
 1. make it OO

--- a/d2pi/cache.py
+++ b/d2pi/cache.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# a simple cache in mm
+
+if not 'd2_dir_cache' in globals():
+    global d2_dir_cache
+
+# global dir cache
+d2_dir_cache = dict()

--- a/d2pi/client.py
+++ b/d2pi/client.py
@@ -3,7 +3,7 @@ import os
 import socket
 
 from config import config
-from utils import md5_for_file, get_logger
+from utils import get_logger
 
 logger = get_logger(config.path_to_watch)
 
@@ -42,8 +42,9 @@ class Client(object):
                     logger.info('upload big file size: %s' % _size)
                     while uploader.offset < _size:
                         try:
-                            logger.info('uploading offset %d' % uploader.offset)
-                            upload = uploader.upload_chunked()
+                            logger.info('uploading offset %d'
+                                        % uploader.offset)
+                            uploader.upload_chunked()
                         except:
                             return
                     uploader.finish(as_file_name)
@@ -175,7 +176,7 @@ class Client(object):
         client = config.client
         try:
             # pylint: disable=E1103
-            m = client.metadata(path)
+            m = client.metadata(path, include_deleted=True)
             if m.get('is_deleted'):
                 cls.delete(path)
             # pylint: enable=E1103

--- a/d2pi/file.py
+++ b/d2pi/file.py
@@ -13,7 +13,7 @@ class File(object):
 
     def __init__(self, size, rev, thumb_exists, bytes,
                  modified, mime_type, path, is_dir, icon, root,
-                 client_mtime, revision):
+                 client_mtime, revision, is_deleted):
         self.size = size
         self.rev = rev
         self.thumb_exists = thumb_exists
@@ -28,6 +28,7 @@ class File(object):
         self.client_mtime = datetime.strptime(client_mtime,
                                               '%a, %d %b %Y %H:%M:%S +0000')
         self.revision = revision
+        self.is_deleted = is_deleted
 
     @property
     def save_to_dir(self):

--- a/d2pi/folder.py
+++ b/d2pi/folder.py
@@ -3,6 +3,10 @@
 import os
 
 from config import config
+from cache import d2_dir_cache
+
+from utils import get_logger
+logger = get_logger(config.path_to_watch)
 
 # pylint: disable=E1103
 
@@ -13,7 +17,8 @@ class Folder(object):
         return '<Dropbox Folder %s>' % self.path
 
     def __init__(self, hash, thumb_exists, bytes,
-                 path, is_dir, icon, root, contents):
+                 path, is_dir, icon, root, contents,
+                 is_deleted):
         self.hash = hash
         self.thumb_exists = thumb_exists
         self.bytes = bytes
@@ -21,19 +26,36 @@ class Folder(object):
         self.is_dir = is_dir
         self.icon = icon
         self.root = root
+        self.is_deleted = is_deleted
         self.contents = contents or []
 
     @property
-    def files(self):
+    def _files(self):
         from file import File
         rs = self._get_contents(need_dir=False)
         return [File(*r) for r in rs]
 
     @property
-    def dirs(self):
+    def files(self):
+        return [f for f in self._files if not f.is_deleted]
+
+    @property
+    def deleted_files(self):
+        return [f for f in self._files if f.is_deleted]
+
+    @property
+    def _dirs(self):
         rs = self._get_contents(need_dir=True)
         fs = [Folder(*r) for r in rs]
         return [Folder.get_by_path(f.path) for f in fs]
+
+    @property
+    def dirs(self):
+        return [d for d in self._dirs if not d.is_deleted]
+
+    @property
+    def deleted_dirs(self):
+        return [d for d in self._dirs if d.is_deleted]
 
     def _get_contents(self, need_dir=False):
         rs = []
@@ -49,8 +71,10 @@ class Folder(object):
                 icon = c.get('icon')
                 root = c.get('root')
                 contents = c.get('contents')
+                is_deleted = c.get('is_deleted', False)
                 rs.append((hash, thumb_exists, bytes,
-                           path, is_dir, icon, root, contents))
+                           path, is_dir, icon, root, contents,
+                           is_deleted))
             else:
                 if c.get('is_dir'):
                     continue
@@ -64,27 +88,49 @@ class Folder(object):
                 is_dir = c.get('is_dir')
                 icon = c.get('icon')
                 root = c.get('root')
+                is_deleted = c.get('is_deleted', False)
                 client_mtime = c.get('client_mtime')
                 revision = c.get('revision')
                 rs.append((size, rev, thumb_exists, bytes,
                            modified, mime_type, path, is_dir,
-                           icon, root, client_mtime, revision))
+                           icon, root, client_mtime, revision,
+                           is_deleted))
         return rs
 
     @classmethod
     def get_by_path(cls, path):
+        path = str(path)
+        _cache = d2_dir_cache.get(path, None)
+        _hash = None
+        try:
+            _hash = _cache.hash if _cache else None
+            if _cache and _cache.hash:
+                logger.info('cache hit for %s' % path)
+        except:
+            _hash = None
         client = config.client
-        md = client.metadata(path)
-        hash = md.get('hash')
-        thumb_exists = md.get('thumb_exists')
-        bytes = md.get('bytes')
-        path = md.get('path')
-        is_dir = md.get('is_dir')
-        icon = md.get('icon')
-        root = md.get('root')
-        contents = md.get('contents')
-        return cls(hash, thumb_exists, bytes,
-                   path, is_dir, icon, root, contents)
+        try:
+            md = client.metadata(path, hash=_hash, include_deleted=True)
+            hash = md.get('hash')
+            thumb_exists = md.get('thumb_exists')
+            bytes = md.get('bytes')
+            path = md.get('path')
+            is_dir = md.get('is_dir')
+            icon = md.get('icon')
+            root = md.get('root')
+            contents = md.get('contents')
+            is_deleted = md.get('is_deleted', False)
+            logger.info('set cache for %s' % path)
+            r = cls(hash, thumb_exists, bytes,
+                    path, is_dir, icon, root, contents,
+                    is_deleted)
+            d2_dir_cache[path] = r
+            return r
+        except:
+            # get metadata wish hash
+            # if no change dropbox will raise exception
+            logger.info('return cache for %s' % path)
+            return _cache if _cache else None
 
     @property
     def save_to_dir(self):

--- a/d2pi/lock.py
+++ b/d2pi/lock.py
@@ -2,30 +2,26 @@
 # this is a very simple lock
 
 
-def set_lock(_lock=True):
-    if not '_d2_lock' in globals():
-        global _d2_lock
-    _d2_lock = _lock
+def set_lock(name='_d2_lock', lock=True):
+    globals()[name] = lock
 
 
-def free_lock():
-    set_lock(_lock=False)
-
-
-def set_upload_lock(_lock=True):
-    if not '_d2_upload_lock' in globals():
-        global _d2_upload_lock
-    _d2_upload_lock = _lock
-
-
-def free_upload_lock():
-    set_upload_lock(_lock=False)
+def free_lock(name='_d2_lock', lock=False):
+    set_lock(name=name, lock=lock)
 
 
 def get_lock(name='_d2_lock'):
     if name in globals():
         return globals().get(name)
     return False
+
+
+def set_upload_lock():
+    set_lock(name='_d2_upload_lock')
+
+
+def free_upload_lock():
+    free_lock(name='_d2_upload_lock')
 
 
 def get_upload_lock():


### PR DESCRIPTION
**Changes**:
1. add a very simple cache, it's dict in memory.
2. better sync_download

`sync_download` will be:
1. check metadata and set hash to cache
2. request dropbox with hash, it no change then return cache object

this will be faster.

and remove `check_dir_deleted`, it will search all folder and sync delete status, may blocked or broken by other events. now new `sync_download` method will handle that.

If file in dropbox and status `is_deleted` is true, and files/folder exists in local, and config require remove local file, then remove local.

If file exists in server with no change, return cache object.
