### PR TITLE
Use os.remove and shutil.rmtree instead of rm (-rf) to remove delete files/dirs

### DIFF
--- a/d2pi/client.py
+++ b/d2pi/client.py
@@ -136,7 +136,7 @@ class Client(object):
         from file_path to save_to_path
         '''
         if d2_files_list.has_value(save_to_path):
-            logger.info('file %s in downloded list, not download'
+            logger.info('file %s in downloaded list, not download'
                         % file_path)
             return False
         r = cls._download(file_path, save_to_path)

--- a/d2pi/watch.py
+++ b/d2pi/watch.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import shutil
 import os
 import time
 from .config import config
@@ -62,14 +63,14 @@ class Watcher(object):
             _path = config.path_to_watch + f.path
             if os.path.exists(_path):
                 logger.info('rm %s' % _path)
-                os.system('rm %s' % _path)
+                os.remove(_path)
         for d in folder.deleted_dirs:
             if f.path in ('/', config.path_to_watch):
                 continue
             _path = config.path_to_watch + d.path
             if os.path.exists(_path):
                 logger.info('rm -rf %s' % _path)
-                os.system('rm -rf %s' % _path)
+                shutil.rmtree(_path)
 
     def clean(self):
         '''
@@ -77,7 +78,7 @@ class Watcher(object):
         '''
         if os.path.exists(config.path_to_watch):
             logger.info('rm -rf %s' % config.path_to_watch)
-            os.system('rm -rf %s' % config.path_to_watch)
+            shutil.rmtree(config.path_to_watch)
 
     def sync_download(self):
         '''


### PR DESCRIPTION
This fixes issue with removal of files/dirs with space in name.
