### PR TITLE
fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 
 language: python
 python:
-    - 2.6
     - 2.7
     - pypy
     - 3.3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,10 @@ from sys import version_info
 __all__ = ['unittest']
 
 if version_info < (2, 7):
-    import unittest2 as unittest
+    try:
+        import unittest2 as unittest
+    except:
+        import unittest
 else:
     import unittest
 


### PR DESCRIPTION
Why travis ci for 2.6.9 had wrong pylint error? This make our lib
error...

https://travis-ci.org/GuoJing/Drop2PI/jobs/99374770
